### PR TITLE
Remove ember-mu-authorization addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ember-material-design-icons-shim": "0.1.10",
     "ember-materialize-shim": "git+https://github.com/cecemel/ember-materialize-shim.git",
     "ember-modal-dialog": "0.8.8",
-    "ember-mu-authorization": "0.1.0",
     "ember-mu-login": "git+https://github.com/cecemel/ember-mu-login.git",
     "ember-new-computed": "1.0.3",
     "ember-place-autocomplete": "0.0.17",


### PR DESCRIPTION
The addon is not required for the simple authorization model we want to configure in the backend